### PR TITLE
[Refactoring] Crawling Page Url Parsing 시 사용 모듈 변경

### DIFF
--- a/crawling/detailPage/DetailPageCrawlingModule.py
+++ b/crawling/detailPage/DetailPageCrawlingModule.py
@@ -3,13 +3,15 @@ import importlib
 
 sub_directory_name = "detailPage"
 
+
 def run_job(crawling_site):
     shop_name, item_name, response = crawling_site
     module_name = sub_directory_name + "." + shop_name + "DetailPageCrawling"
     module = importlib.import_module(module_name)
     return module.get_detail_page(response, item_name)
 
-def crawling_site(detail_sites): # input : ['morecherry', '플랫폼 라운드 로퍼 앵클 .47 (2color)', <Response [200]>]
+
+def crawling_site(detail_sites):  # input : ['morecherry', '플랫폼 라운드 로퍼 앵클 .47 (2color)', <Response [200]>]
     output = []
     with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
         results = pool.imap(run_job, detail_sites)

--- a/crawling/detailPage/DetailPageUrlThread.py
+++ b/crawling/detailPage/DetailPageUrlThread.py
@@ -1,10 +1,5 @@
 import requests
 import concurrent.futures
-import multiprocessing
-
-threads = []
-result = []
-
 
 def fetch_url(each_url):
     shop_name, item_name, detail_info_url, header_values = each_url
@@ -26,6 +21,5 @@ def get_total_detail_info_response(url):
         results = executor.map(fetch_url, url)
         for result in results:
             output.append(list(result))
-        executor.shutdown()
 
     return output

--- a/crawling/urlCollection/MoreCherryUrlsCollector.py
+++ b/crawling/urlCollection/MoreCherryUrlsCollector.py
@@ -12,7 +12,6 @@ more_cherry_total_url = []
 
 
 def fetch_url(url):
-
     crawling_module_name = "MoreCherrySiteCrawling"
     find_key = '<ul class="prdList grid4">'
 
@@ -28,8 +27,8 @@ def fetch_url(url):
         else:
             break
 
-def gather_urls():
 
+def gather_urls():
     shop_name = "morecherry"
 
     urls = [

--- a/crawling/urlCollection/MoreCherryUrlsCollector.py
+++ b/crawling/urlCollection/MoreCherryUrlsCollector.py
@@ -1,47 +1,46 @@
 import requests
-import threading
+import concurrent.futures
 from common.ProductTypes import product_types
 
-base_url = "https://more-cherry.com"
-crawling_module_name = "MoreCherrySiteCrawling"
-shop_name = "morecherry"
-find_key = '<ul class="prdList grid4">'
 user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, likeGecko) Chrome/109.0.0.0 Safari/537.36"
+base_url = "https://more-cherry.com"
 header = {
     'Referrer': base_url,
     'user-agent': user_agent
 }
 more_cherry_total_url = []
-urls = [
-    ("https://more-cherry.com/category/outwear/24/?page=", product_types.OUTWEAR.name),
-    ("https://more-cherry.com/category/top/25/?page=", product_types.TOP.name),
-    ("https://more-cherry.com/category/pants/26/?page=", product_types.BOTTOM.name),
-    ("https://more-cherry.com/category/accessory/28/?page=", product_types.ACCESSORY.name),
-    ("https://more-cherry.com/category/shoes/42/?page=", product_types.SHOES.name),
-]
-threads = []
 
 
-def fetch_url(url, item_type):
+def fetch_url(url):
+
+    crawling_module_name = "MoreCherrySiteCrawling"
+    find_key = '<ul class="prdList grid4">'
+
+    each_url, product_type = url
     page_number = 1
 
     while True:
-        temp_url = url + str(page_number)
+        temp_url = each_url + str(page_number)
         response = requests.get(temp_url, headers=header)
         page_number += 1
         if find_key in response.text:
-            more_cherry_total_url.append([crawling_module_name, response, item_type])
+            more_cherry_total_url.append([crawling_module_name, response, product_type])
         else:
             break
 
 def gather_urls():
-    for each_url in urls:
-        url, item_type = each_url
-        thread = threading.Thread(target=fetch_url, args=(url, item_type))
-        threads.append(thread)
-        thread.start()
 
-    for thread in threads:
-        thread.join()
+    shop_name = "morecherry"
+
+    urls = [
+        ("https://more-cherry.com/category/outwear/24/?page=", product_types.OUTWEAR.name),
+        ("https://more-cherry.com/category/top/25/?page=", product_types.TOP.name),
+        ("https://more-cherry.com/category/pants/26/?page=", product_types.BOTTOM.name),
+        ("https://more-cherry.com/category/accessory/28/?page=", product_types.ACCESSORY.name),
+        ("https://more-cherry.com/category/shoes/42/?page=", product_types.SHOES.name),
+    ]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as executor:
+        executor.map(fetch_url, urls)
 
     return [more_cherry_total_url, base_url, user_agent, shop_name]

--- a/crawling/urlCollection/PorternaUrlsCollector.py
+++ b/crawling/urlCollection/PorternaUrlsCollector.py
@@ -1,48 +1,45 @@
+import concurrent.futures
 import requests
-import threading
 from common.ProductTypes import product_types
 
-base_url = "https://porterna.com"
-crawling_module_name = "PorternaSiteCrawling"
-shop_name = "porterna"
-find_key = 'col  col20 floatleft xans-record-'
 user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
+base_url = "https://porterna.com"
 header = {
     'Referrer': base_url,
     'user-agent': user_agent
 }
 porterna_total_url = []
-urls = [
-    ("https://porterna.com/product/list.html?cate_no=541&page=", product_types.OUTWEAR.name),
-    ("https://porterna.com/product/list.html?cate_no=789&page=", product_types.TOP.name),
-    ("https://porterna.com/product/list.html?cate_no=28&page=", product_types.BOTTOM.name),
-    ("https://porterna.com/product/list.html?cate_no=44&page=", product_types.ACCESSORY.name),
-    ("https://porterna.com/product/list.html?cate_no=79&page=", product_types.SHOES.name),
-]
-threads = []
 
 
-def fetch_url(url, item_type):
+def fetch_url(url):
+    crawling_module_name = "PorternaSiteCrawling"
+    find_key = 'col  col20 floatleft xans-record-'
+
+    each_url, product_type = url
     page_number = 1
 
     while True:
-        temp_url = url + str(page_number)
+        temp_url = each_url + str(page_number)
         response = requests.get(temp_url, headers=header)
         page_number += 1
         if find_key in response.text:
-            porterna_total_url.append([crawling_module_name, response, item_type])
+            porterna_total_url.append([crawling_module_name, response, product_type])
         else:
             break
 
 
 def gather_urls():
-    for each_url in urls:
-        url, item_type = each_url
-        thread = threading.Thread(target=fetch_url, args=(url, item_type))
-        threads.append(thread)
-        thread.start()
+    shop_name = "porterna"
 
-    for thread in threads:
-        thread.join()
+    urls = [
+        ("https://porterna.com/product/list.html?cate_no=541&page=", product_types.OUTWEAR.name),
+        ("https://porterna.com/product/list.html?cate_no=789&page=", product_types.TOP.name),
+        ("https://porterna.com/product/list.html?cate_no=28&page=", product_types.BOTTOM.name),
+        ("https://porterna.com/product/list.html?cate_no=44&page=", product_types.ACCESSORY.name),
+        ("https://porterna.com/product/list.html?cate_no=79&page=", product_types.SHOES.name),
+    ]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as executor:
+        executor.map(fetch_url, urls)
 
     return [porterna_total_url, base_url, user_agent, shop_name]

--- a/crawling/urlCollection/TheVerlinUrlsCollector.py
+++ b/crawling/urlCollection/TheVerlinUrlsCollector.py
@@ -1,47 +1,45 @@
 import requests
-import threading
+import concurrent.futures
 from common.ProductTypes import product_types
 
-base_url = "https://theverlin.com/"
-crawling_module_name = "TheVerlinSiteCrawling"
-shop_name = "theverlin"
-find_key = 'class="item xans-record-">'
 user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
+base_url = "https://theverlin.com/"
 header = {
     'Referrer': base_url,
     'user-agent': user_agent
 }
 the_verlin_total_url = []
-urls = [
-    ("https://theverlin.com/product/list.html?cate_no=42&page=", product_types.OUTWEAR.name),
-    ("https://theverlin.com/product/list.html?cate_no=43&page=", product_types.TOP.name),
-    ("https://theverlin.com/product/list.html?cate_no=44&page=", product_types.BOTTOM.name),
-    ("https://theverlin.com/product/list.html?cate_no=48&page=", product_types.ACCESSORY.name),
-    ("https://theverlin.com/category/shoes/193/?page=", product_types.SHOES.name),
-]
-threads = []
 
-def fetch_url(url, item_type):
+
+def fetch_url(url):
+    crawling_module_name = "TheVerlinSiteCrawling"
+    find_key = 'class="item xans-record-">'
+
+    each_url, product_type = url
     page_number = 1
 
     while True:
-        temp_url = url + str(page_number)
+        temp_url = each_url + str(page_number)
         response = requests.get(temp_url, headers=header)
         page_number += 1
         if find_key in response.text:
-            the_verlin_total_url.append([crawling_module_name, response, item_type])
+            the_verlin_total_url.append([crawling_module_name, response, product_type])
         else:
             break
 
 
 def gather_urls():
-    for each_url in urls:
-        url, item_type = each_url
-        thread = threading.Thread(target=fetch_url, args=(url, item_type))
-        threads.append(thread)
-        thread.start()
+    shop_name = "theverlin"
 
-    for thread in threads:
-        thread.join()
+    urls = [
+        ("https://theverlin.com/product/list.html?cate_no=42&page=", product_types.OUTWEAR.name),
+        ("https://theverlin.com/product/list.html?cate_no=43&page=", product_types.TOP.name),
+        ("https://theverlin.com/product/list.html?cate_no=44&page=", product_types.BOTTOM.name),
+        ("https://theverlin.com/product/list.html?cate_no=48&page=", product_types.ACCESSORY.name),
+        ("https://theverlin.com/category/shoes/193/?page=", product_types.SHOES.name),
+    ]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as executor:
+        executor.map(fetch_url, urls)
 
     return [the_verlin_total_url, base_url, user_agent, shop_name]

--- a/crawling/urlCollection/UrlCollectionModule.py
+++ b/crawling/urlCollection/UrlCollectionModule.py
@@ -3,10 +3,12 @@ import importlib
 
 sub_directory_name = "urlCollection"
 
+
 def run_job(module_name):
     module_name = sub_directory_name + "." + module_name
     module = importlib.import_module(module_name)
     return module.gather_urls()
+
 
 def url_collecting():
     module_names = ['MoreCherryUrlsCollector', 'TheVerlinUrlsCollector', 'PorternaUrlsCollector']


### PR DESCRIPTION
#### 기능

- threading Module을 걷어내고 concurrent.futures Module을 사용해 I/O Bound 작업을 진행합니다.

#### 상세 내용

- python threading 성능보다 더 나은 concurrent.futures.ThreadPoolExecutor를 사용합니다.

- ThreadPoolExecutor는 Context Manager를 이용하여 GIL이 적용되지 않는 Thread를 생성할 수 있습니다.

- 또한, 내부적으로 queue.Queue를 사용해 작업을 관리하기 때문에 Thread 사이 작업 분배 및 동기화 등을 더욱 효율적으로 처리할 수 있습니다.

🍎 따라서, threading module 대신 concurrent.futures를 사용합니다.

#### issue number and link
❌
